### PR TITLE
add lemma length_app_comm

### DIFF
--- a/doc/changelog/01-added/75-add-length_app_comm.rst
+++ b/doc/changelog/01-added/75-add-length_app_comm.rst
@@ -1,0 +1,5 @@
+- in `List.v`
+
+  + lemma `length_app_comm`
+    (`#75 <https://github.com/coq/stdlib/pull/75>`_,
+    by Nicholas Hubbard).

--- a/theories/Lists/List.v
+++ b/theories/Lists/List.v
@@ -239,6 +239,14 @@ Section Facts.
     intro l; induction l; simpl; auto.
   Qed.
 
+  Lemma length_app_comm : forall l l' : list A, length (l++l') = length (l'++l).
+  Proof.
+    intros.
+    repeat rewrite length_app.
+    rewrite Nat.add_comm.
+    reflexivity.
+  Qed.
+
   Lemma last_length : forall (l : list A) a, length (l ++ [a]) = S (length l).
   Proof.
     intros ; rewrite length_app ; simpl.


### PR DESCRIPTION
This PR adds to List.v a lemma: `Lemma length_app_comm : forall l l' : list A, length (l++l') = length (l'++l).`

I'd like to preface by saying that I am new to Coq so may be ignorant of many things. However, I was in need of such a lemma in one of my proofs and was surprised that an obvious fact such as this did not already exist in the stdlib. I hope that `length_app_comm` is a good name for this. I read over https://github.com/coq/coq/pull/18564 where the naming convention of these lemmas was discussed, and I believe that I followed it correctly.

One thing I am unsure about is if I was correct to add the new lemma under the `Global Hint Rewrite` here:

```coq
Global Hint Rewrite
  rev_involutive (* rev (rev l) = l *)
  rev_unit (* rev (l ++ a :: nil) = a :: rev l *)
  map_nth (* nth n (map f l) (f d) = f (nth n l d) *)
  length_map (* length (map f l) = length l *)
  length_seq (* length (seq start len) = len *)
  length_app (* length (l ++ l') = length l + length l' *)
  length_app_comm (* length (l ++ l') = length (l' ++ l) *)
  length_rev (* length (rev l) = length l *)
  app_nil_r (* l ++ nil = l *)
  : list.
```
Was this the correct thing to do?

Please let me know if you believe `length_app_comm` would be a good addition to List.v, and if anything else needs to be done. Thanks!

- [x] Added **changelog**.

