### PR TITLE
Wrap coqdoc calls

### DIFF
--- a/dev/with-rocq-wrap.sh
+++ b/dev/with-rocq-wrap.sh
@@ -23,7 +23,13 @@ cat > .wrappers/coqdep <<EOF
 exec rocq dep "\$@"
 EOF
 
-chmod +x .wrappers/coqc .wrappers/coqdep
+cat > .wrappers/coqdoc <<EOF
+#!/bin/sh
+# hash = $rocqhash
+exec rocq doc "\$@"
+EOF
+
+chmod +x .wrappers/coqc .wrappers/coqdep .wrappers/coqdoc
 
 ln -s "$(ocamlfind query rocq-runtime.kernel)" .wrappers/kernel
 


### PR DESCRIPTION
coqdoc calls should be wrapped to not require the coq-core compatibility layer. 