### PR TITLE
Stdlib rocq manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,5 @@ user-contrib/Ltac2/dune
 
 .wrappers
 rocq-stdlib-doc.opam
+doc/stdlib/Library.fdb_latexmk
+doc/stdlib/Library.fls

--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,6 @@ config/coq_config.py
 config/dune.c_flags
 ide/coqide/config.ml
 dev/ocamldebug-coq
-coqdoc.sty
-coqdoc.css
 time-of-build*.log
 time-of-build*.log2
 time-of-build*.log3

--- a/doc/common/macros.tex
+++ b/doc/common/macros.tex
@@ -91,6 +91,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%
 
 \newcommand{\Coq}{\textsc{Coq}}
+\newcommand{\Rocq}{\textsc{Rocq}}
 \newcommand{\gallina}{\textsc{Gallina}}
 \newcommand{\Gallina}{\textsc{Gallina}}
 \newcommand{\CoqIDE}{\textsc{CoqIDE}}

--- a/doc/sphinx/_static/coqdoc.css
+++ b/doc/sphinx/_static/coqdoc.css
@@ -1,0 +1,119 @@
+/************************************************************************/
+/*         *      The Rocq Prover / The Rocq Development Team           */
+/*  v      *         Copyright INRIA, CNRS and contributors             */
+/* <O___,, * (see version control and CREDITS file for authors & dates) */
+/*   \VV/  **************************************************************/
+/*    //   *    This file is distributed under the terms of the         */
+/*         *     GNU Lesser General Public License Version 2.1          */
+/*         *     (see LICENSE file for the text of the license)         */
+/************************************************************************/
+/* Taken from CoqDoc's default stylesheet */
+
+.coqdoc-constructor {
+    color: rgb(60%,0%,0%);
+}
+
+.coqdoc-var {
+    color: rgb(40%,0%,40%);
+}
+
+.coqdoc-variable {
+    color: rgb(40%,0%,40%);
+}
+
+.coqdoc-definition {
+    color: rgb(0%,40%,0%);
+}
+
+.coqdoc-abbreviation {
+    color: rgb(0%,40%,0%);
+}
+
+.coqdoc-lemma {
+    color: rgb(0%,40%,0%);
+}
+
+.coqdoc-instance {
+    color: rgb(0%,40%,0%);
+}
+
+.coqdoc-projection {
+    color: rgb(0%,40%,0%);
+}
+
+.coqdoc-method {
+    color: rgb(0%,40%,0%);
+}
+
+.coqdoc-inductive {
+    color: rgb(0%,0%,80%);
+}
+
+.coqdoc-record {
+    color: rgb(0%,0%,80%);
+}
+
+.coqdoc-class {
+    color: rgb(0%,0%,80%);
+}
+
+.coqdoc-keyword {
+    color : #cf1d1d;
+}
+
+/* Custom additions */
+
+.coqdoc-tactic {
+    font-weight: bold;
+}
+
+.smallcaps {
+    font-variant: small-caps;
+}
+
+
+:root {
+    --refman-custom-primary-blue: #260086;
+    --refman-custom-primary-blue-2: #040b92;
+    --refman-custom-secondary-orange: #ff540a;
+    --refman-custom-secondary-orange-2: #ffe9df;
+}
+
+.btn-info:hover, a:hover, a.wy-text-info:hover {
+    color: var(--refman-custom-primary-blue-2) !important
+}
+
+.wy-menu-vertical header, .wy-menu-vertical p.caption, .rst-content .wy-alert-neutral.admonition-todo a, .rst-content .wy-alert-neutral.admonition a, .rst-content .wy-alert-neutral.attention a, .rst-content .wy-alert-neutral.caution a, .rst-content .wy-alert-neutral.danger a, .rst-content .wy-alert-neutral.error a, .rst-content .wy-alert-neutral.hint a, .rst-content .wy-alert-neutral.important a, .rst-content .wy-alert-neutral.note a, .rst-content .wy-alert-neutral.seealso a, .rst-content .wy-alert-neutral.tip a, .rst-content .wy-alert-neutral.warning a, .wy-alert.wy-alert-neutral a, a, .wy-text-info, .btn-link, .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-nav .wy-menu-vertical header, .rst-versions a, .rst-content a code, .rst-content a tt, html.writer-html4 .rst-content dl:not(.docutils)>dt, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt, html.writer-html4 .rst-content dl:not(.docutils)>dt:before, html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt:before {
+    color: var(--refman-custom-primary-blue) !important
+}
+
+.rst-content .note .admonition-title,.rst-content .note .wy-alert-title,.rst-content .seealso .admonition-title,.rst-content .seealso .wy-alert-title,.rst-content .wy-alert-info.admonition-todo .admonition-title,.rst-content .wy-alert-info.admonition-todo .wy-alert-title,.rst-content .wy-alert-info.admonition .admonition-title,.rst-content .wy-alert-info.admonition .wy-alert-title,.rst-content .wy-alert-info.attention .admonition-title,.rst-content .wy-alert-info.attention .wy-alert-title,.rst-content .wy-alert-info.caution .admonition-title,.rst-content .wy-alert-info.caution .wy-alert-title,.rst-content .wy-alert-info.danger .admonition-title,.rst-content .wy-alert-info.danger .wy-alert-title,.rst-content .wy-alert-info.error .admonition-title,.rst-content .wy-alert-info.error .wy-alert-title,.rst-content .wy-alert-info.hint .admonition-title,.rst-content .wy-alert-info.hint .wy-alert-title,.rst-content .wy-alert-info.important .admonition-title,.rst-content .wy-alert-info.important .wy-alert-title,.rst-content .wy-alert-info.tip .admonition-title,.rst-content .wy-alert-info.tip .wy-alert-title,.rst-content .wy-alert-info.warning .admonition-title,.rst-content .wy-alert-info.warning .wy-alert-title,.rst-content .wy-alert.wy-alert-info .admonition-title,.wy-alert.wy-alert-info .rst-content .admonition-title,.wy-alert.wy-alert-info .wy-alert-title {
+    background: var(--refman-custom-primary-blue) !important
+}
+
+html.writer-html4 .rst-content dl:not(.docutils)>dt,html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple)>dt {
+    background: var(--refman-custom-secondary-orange-2) !important;
+    color: var(--refman-custom-primary-blue) !important;
+    border-top: 3px solid var(--refman-custom-secondary-orange) !important;
+}
+
+.wy-tray-container li.wy-tray-item-info, .btn-info, .wy-menu-vertical a:active, .wy-side-nav-search, .wy-dropdown-menu>dd>a:hover, .wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a:hover, .wy-side-nav-search img, .wy-nav .wy-menu-vertical a:hover, .wy-nav-top, .wy-nav-top img {
+    background-color: var(--refman-custom-secondary-orange) !important
+}
+
+.wy-side-nav-search input[type=text] {
+    border-color: var(--refman-custom-primary-blue-2) !important
+}
+
+.rst-versions, .wy-nav-side {
+    background: #dedede !important;
+}
+
+.wy-side-nav-search>div.version {
+    color: #dedede !important;
+}
+
+.wy-menu-vertical a:hover {
+    background-color: #494949 !important;
+    color: #dedede !important;
+}

--- a/doc/sphinx/introduction.rst
+++ b/doc/sphinx/introduction.rst
@@ -1,5 +1,5 @@
-The is the reference manual of the Standard Library of Coq.
-It mostly presents a few tactics.
+This is the reference manual of the Standard Library of the Rocq Prover.
+It mostly presents a few notations and tactics.
 
 .. only:: html
 

--- a/doc/sphinx/language/coq-library.rst
+++ b/doc/sphinx/language/coq-library.rst
@@ -29,8 +29,8 @@ These directories belong to the initial load path of the system, and
 the modules they provide are compiled at installation time. So they
 are directly accessible with the command ``Require``.
 
-The different modules of the Coq standard library are documented
-online at https://coq.inria.fr/stdlib/.
+The different modules of the Rocq standard library are documented
+online at https://rocq-prover.org/stdlib/.
 
 Peano’s arithmetic (nat)
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -250,7 +250,7 @@ Floats library
 ~~~~~~~~~~~~~~
 
 The standard library has a small ``Floats`` module for accessing
-processor floating-point operations through the Coq kernel.
+processor floating-point operations through the Rocq kernel.
 However, while this module supports computation and has a bit-level
 specification, it doesn't include elaborate theorems, such as a link
 to real arithmetic or various error bounds. To do proofs by

--- a/doc/stdlib/Library.tex
+++ b/doc/stdlib/Library.tex
@@ -23,9 +23,9 @@ General Public License Version 2.1.}
 \tableofcontents
 
 \newpage
-% \section*{The \Coq\ standard library}
+% \section*{The \Rocq\ standard library}
 
-This document is a short description of the \Coq\ standard library.
+This document is a short description of the \Rocq\ standard library.
 This library comes with the system as a complement of the core library
 (the {\bf Init} library ; see the Reference Manual for a description
 of this library). It provides a set of modules directly available


### PR DESCRIPTION
This updates (actually, sets as it was not there) the Stdlib refman coqdoc.css style file to the new Rocq Prover defaults.