### PR TITLE
Suppress 2 "From Stdlib" warnings

### DIFF
--- a/theories/Numbers/DecimalR.v
+++ b/theories/Numbers/DecimalR.v
@@ -14,7 +14,7 @@
     are bijections. *)
 
 From Stdlib Require Import Decimal DecimalFacts DecimalPos DecimalZ DecimalQ Rdefinitions.
-Require Import PeanoNat.
+From Stdlib Require Import PeanoNat.
 
 Lemma of_IQmake_to_decimal num den :
   match IQmake_to_decimal num den with

--- a/theories/Reals/Zfloor.v
+++ b/theories/Reals/Zfloor.v
@@ -5,7 +5,7 @@
 (*                                                                            *)
 (******************************************************************************)
 
-Require Import Rbase Rfunctions Lra Lia.
+From Stdlib Require Import Rbase Rfunctions Lra Lia.
 
 Local Open Scope R_scope.
 


### PR DESCRIPTION
`Reals.Zfloor.v` and `Numbers.DecimalR` were complaining about naked `Require Import`.